### PR TITLE
refactor to support announcing mdns records as well as resolving them

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,10 +4,13 @@ libmicrodns_la_SOURCES = mdns.c rr.c compat.c
 
 lib_LTLIBRARIES = libmicrodns.la
 
-noinst_PROGRAMS = test
+noinst_PROGRAMS = test announce
 test_SOURCES = main.c
 test_LDADD = libmicrodns.la
 test_LDADD += @LIBSOCKET@
+announce_SOURCES = announce.c
+announce_LDADD = libmicrodns.la
+announce_LDADD += @LIBSOCKET@
 
 pkginclude_HEADERS = microdns.h rr.h
 pkgconfig_DATA = microdns.pc

--- a/announce.c
+++ b/announce.c
@@ -1,0 +1,66 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include "microdns.h"
+
+volatile sig_atomic_t sigflag = 0;
+
+void sighandler(int signum)
+{
+        char s[] = "SIGINT received, exiting ...\n";
+
+        write(fileno(stdout), s, sizeof(s));
+        sigflag = 1;
+}
+
+bool stop(void *cbarg)
+{
+        return (sigflag ? true : false);
+}
+
+void callback(void *cbarg, int r, const struct rr_entry *entry)
+{
+        struct mdns_ctx *ctx = (struct mdns_ctx *) cbarg;
+        struct mdns_hdr hdr = {0};
+        struct rr_entry answer = {0};
+
+        hdr.flags |= FLAG_QR;
+        hdr.flags |= FLAG_AA;
+        hdr.num_ans_rr = 1;
+
+        answer.name     = entry->name;
+        answer.type     = entry->type;
+        answer.rr_class = entry->rr_class;
+        answer.ttl      = 120;
+
+        sprintf(answer.data.A.addr_str, "192.168.1.1");
+        inet_pton(AF_INET, answer.data.A.addr_str, &answer.data.A.addr);
+        mdns_send(ctx, &hdr, &answer);
+}
+
+int main(int argc, char *argv[])
+{
+        int r = 0;
+        char err[128];
+        struct mdns_ctx *ctx;
+
+        signal(SIGINT, sighandler);
+        signal(SIGTERM, sighandler);
+
+        if ((r = mdns_init(&ctx, MDNS_ADDR_IPV4, MDNS_PORT)) < 0)
+                goto err;
+
+        // test with `ping mdnshost.local`
+        mdns_announce(ctx, "mdnshost.local", RR_A, callback, ctx);
+
+        if ((r = mdns_serve(ctx, stop, NULL)) < 0)
+                goto err;
+err:
+        if (r < 0) {
+                mdns_strerror(r, err, sizeof(err));
+                fprintf(stderr, "fatal: %s\n", err);
+        }
+        mdns_cleanup(ctx);
+        return (0);
+}

--- a/compat.h
+++ b/compat.h
@@ -96,7 +96,6 @@ static inline int os_close(sock_t s) {return (closesocket(s));}
 static inline int os_wouldblock(void) {return (WSAGetLastError() == WSAEWOULDBLOCK);}
 
 # define strerror_r(x, y, z) strerror_s(y, z, x)
-# define strtok_r strtok_s
 
 #ifndef HAVE_INET_NTOP
 extern const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);

--- a/libmdns.def
+++ b/libmdns.def
@@ -8,3 +8,5 @@ EXPORTS
             mdns_print
             mdns_strerror
             mdns_listen
+            mdns_announce
+            mdns_serve

--- a/main.c
+++ b/main.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
 #include <signal.h>
 
 #include "microdns.h"
@@ -34,7 +35,7 @@ bool stop(void *p_cookie)
         return (sigflag ? true : false);
 }
 
-void callback(void *p_cookie, int status, struct rr_entry *entries)
+void callback(void *p_cookie, int status, const struct rr_entry *entries)
 {
         char err[128];
 
@@ -56,7 +57,7 @@ int main(void)
 
         if ((r = mdns_init(&ctx, MDNS_ADDR_IPV4, MDNS_PORT)) < 0)
                 goto err;
-        if ((r = mdns_listen(ctx, "_googlecast._tcp.local", 10, &stop, &callback, NULL)) < 0)
+        if ((r = mdns_listen(ctx, "_googlecast._tcp.local", RR_PTR, 10, &stop, &callback, NULL)) < 0)
                 goto err;
 err:
         if (r < 0) {

--- a/mdns.c
+++ b/mdns.c
@@ -31,18 +31,8 @@ struct mdns_ctx {
         struct sockaddr_storage addr;
 };
 
-struct mdns_hdr {
-        uint16_t id;
-        uint16_t flags;
-        uint16_t num_qn;
-        uint16_t num_ans_rr;
-        uint16_t num_auth_rr;
-        uint16_t num_add_rr;
-};
-
 static int mdns_resolve(struct sockaddr_storage *, const char *, unsigned short);
-static ssize_t mdns_write(uint8_t *, const struct mdns_hdr *, const struct rr_entry *);
-static struct rr_entry *mdns_read(const uint8_t *, size_t);
+static ssize_t mdns_write_hdr(uint8_t *, const struct mdns_hdr *);
 static int strrcmp(const char *, const char *);
 
 static int
@@ -144,9 +134,9 @@ mdns_cleanup(struct mdns_ctx *ctx)
 }
 
 static ssize_t
-mdns_write(uint8_t *ptr, const struct mdns_hdr *hdr, const struct rr_entry *entry)
+mdns_write_hdr(uint8_t *ptr, const struct mdns_hdr *hdr)
 {
-        uint8_t *name, *p = ptr;
+        uint8_t *p = ptr;
 
         p = write_u16(p, hdr->id);
         p = write_u16(p, hdr->flags);
@@ -154,45 +144,34 @@ mdns_write(uint8_t *ptr, const struct mdns_hdr *hdr, const struct rr_entry *entr
         p = write_u16(p, hdr->num_ans_rr);
         p = write_u16(p, hdr->num_auth_rr);
         p = write_u16(p, hdr->num_add_rr);
-        if ((name = rr_encode(entry->name)) == NULL)
-                return (MDNS_STDERR);
-        p = write_raw(p, name);
-        p = write_u16(p, entry->type);
-        p = write_u16(p, (entry->rr_class & ~0x8000) | (entry->msbit << 15));
-
-        free(name);
         return (p - ptr);
 }
 
 int
-mdns_send(const struct mdns_ctx *ctx, enum rr_type type, const char *name)
+mdns_send(const struct mdns_ctx *ctx, const struct mdns_hdr *hdr, const struct rr_entry *entries)
 {
-        struct mdns_hdr hdr;
-        struct rr_entry entry;
-        uint8_t buf[MDNS_PKT_MAXSZ];
-        ssize_t n, r;
+        uint8_t buf[MDNS_PKT_MAXSZ] = {0};
+        const struct rr_entry *entry = entries;
+        ssize_t i, n = 0, l, r;
 
-        if (strlen(name) >= MDNS_DN_MAXSZ) {
-                errno = EINVAL;
+        if (!entries) return (MDNS_STDERR);
+
+        if ((l = mdns_write_hdr(buf, hdr)) < 0) {
                 return (MDNS_STDERR);
         }
+        n += l;
 
-        memset(&hdr, 0, sizeof(hdr));
-        hdr.num_qn = 1;
-        entry.type = type;
-        entry.rr_class = RR_IN;
-        entry.msbit = 0; // ask for multicast responses
-        if((entry.name = strdup(name)) == NULL)
-                return (MDNS_STDERR);
-
-        if ((n = mdns_write(buf, &hdr, &entry)) < 0) {
-                free(entry.name);
-                return (MDNS_STDERR);
+        for (entry = entries; entry; entry = entry->next) {
+        l = rr_write(buf+n, entry, (hdr->flags & FLAG_QR) > 0);
+                if (l < 0) {
+                        return (MDNS_STDERR);
+                }
+                n += l;
         }
+
         r = sendto(ctx->sock, (const char *) buf, n, 0,
-            (const struct sockaddr *) &ctx->addr, ss_len(&ctx->addr));
+                (const struct sockaddr *) &ctx->addr, ss_len(&ctx->addr));
 
-        free(entry.name);
         return (r < 0 ? MDNS_NETERR : 0);
 }
 
@@ -208,63 +187,56 @@ mdns_free(struct rr_entry *entries)
         }
 }
 
-static struct rr_entry *
-mdns_read(const uint8_t *ptr, size_t n)
+static const uint8_t *
+mdns_read_header(const uint8_t *ptr, size_t n, struct mdns_hdr *hdr)
 {
-        const uint8_t *root = ptr;
-        struct mdns_hdr hdr;
-        struct rr_entry *entry, *entries = NULL;
-        int num_entry;
-
-        if (n <= sizeof(hdr)) {
+        if (n <= sizeof(struct mdns_hdr)) {
                 errno = ENOSPC;
-                return (NULL);
+                return NULL;
         }
-        memcpy(&hdr, ptr, sizeof(hdr));
-        ptr += sizeof(hdr);
-        n -= sizeof(hdr);
+        ptr = read_u16(ptr, &n, &hdr->id);
+        ptr = read_u16(ptr, &n, &hdr->flags);
+        ptr = read_u16(ptr, &n, &hdr->num_qn);
+        ptr = read_u16(ptr, &n, &hdr->num_ans_rr);
+        ptr = read_u16(ptr, &n, &hdr->num_auth_rr);
+        ptr = read_u16(ptr, &n, &hdr->num_add_rr);
+        return ptr;
+}
 
-        if (ntohs(hdr.num_qn) > 0) {
-                errno = ENOTSUP; // XXX support only answers
-                return (NULL);
-        }
-        num_entry = ntohs(hdr.num_ans_rr) + ntohs(hdr.num_add_rr);
+int
+mdns_recv(const struct mdns_ctx *ctx, struct mdns_hdr *hdr, struct rr_entry **entries)
+{
+        uint8_t buf[MDNS_PKT_MAXSZ];
+        ssize_t n, num_entry;
+        struct rr_entry *entry;
+
+        *entries = NULL;
+again:  
+        if ((n = recv(ctx->sock, (char *) buf, sizeof(buf), 0)) < 0)
+                return (MDNS_NETERR);
+
+        const uint8_t *ptr = mdns_read_header(buf, n, hdr);
+
+        num_entry = hdr->num_qn + hdr->num_ans_rr + hdr->num_add_rr;
         for (int i = 0; i < num_entry; ++i) {
                 entry = calloc(1, sizeof(struct rr_entry));
                 if (!entry)
                         goto err;
-                ptr = rr_read(ptr, &n, root, entry, 1);
+                ptr = rr_read(ptr, &n, buf, entry, (hdr->flags & FLAG_QR) > 0);
                 if (!ptr) {
                         errno = ENOSPC;
                         goto err;
                 }
-                entry->next = entries;
-                entries = entry;
+                entry->next = *entries;
+                *entries = entry;
         }
-        return (entries);
-err:
-        mdns_free(entries);
-        return (NULL);
-}
-
-int
-mdns_recv(const struct mdns_ctx *ctx, struct rr_entry **entries)
-{
-        uint8_t buf[MDNS_PKT_MAXSZ];
-        ssize_t n;
-
-        *entries = NULL;
-again:
-        if ((n = recv(ctx->sock, (char *) buf, sizeof(buf), 0)) < 0)
-                return (MDNS_NETERR);
-
-        *entries = mdns_read(buf, n);
         if (*entries == NULL) {
-                if (errno == ENOTSUP)
-                        goto again;
                 return (MDNS_STDERR);
         }
         return (0);
+err:
+        mdns_free(*entries);
+        return (MDNS_STDERR);
 }
 
 void
@@ -301,31 +273,42 @@ strrcmp(const char *s1, const char *s2)
 }
 
 int
-mdns_listen(const struct mdns_ctx *ctx, const char *name, unsigned int interval,
+mdns_listen(const struct mdns_ctx *ctx, const char *name, enum rr_type type, unsigned int interval,
     mdns_stop_func stop, mdns_callback callback, void *p_cookie)
 {
         int r;
         time_t t1, t2;
+        struct mdns_hdr hdr = {0};
+        struct rr_entry qn = {0};
+
+        hdr.num_qn  = 1;
+        qn.name     = (char *)name;
+        qn.type     = type;
+        qn.rr_class = RR_IN;
 
         if (setsockopt(ctx->sock, SOL_SOCKET, SO_RCVTIMEO, (const void *) &os_deadline, sizeof(os_deadline)) < 0)
                 return (MDNS_NETERR);
         if (setsockopt(ctx->sock, SOL_SOCKET, SO_SNDTIMEO, (const void *) &os_deadline, sizeof(os_deadline)) < 0)
                 return (MDNS_NETERR);
 
-        if ((r = mdns_send(ctx, RR_PTR, name)) < 0) // send a first probe request
+        if ((r = mdns_send(ctx, &hdr, &qn)) < 0) // send a first probe request
                 callback(p_cookie, r, NULL);
         for (t1 = t2 = time(NULL); stop(p_cookie) == false; t2 = time(NULL)) {
+                struct mdns_hdr ahdr = {0};
                 struct rr_entry *entries;
 
                 if (difftime(t2, t1) >= (double) interval) {
-                        if ((r = mdns_send(ctx, RR_PTR, name)) < 0) {
+                        if ((r = mdns_send(ctx, &hdr, &qn)) < 0) {
                                 callback(p_cookie, r, NULL);
                                 continue;
                         }
                         t1 = t2;
                 }
-                r = mdns_recv(ctx, &entries);
+                r = mdns_recv(ctx, &ahdr, &entries);
                 if (r == MDNS_NETERR && os_wouldblock())
+                        continue;
+
+                if (ahdr.num_ans_rr + ahdr.num_add_rr == 0)
                         continue;
 
                 for (struct rr_entry *entry = entries; entry; entry = entry->next) {

--- a/mdns.c
+++ b/mdns.c
@@ -250,7 +250,7 @@ mdns_read(const uint8_t *ptr, size_t n)
                 entry = calloc(1, sizeof(struct rr_entry));
                 if (!entry)
                         goto err;
-                ptr = rr_read(ptr, &n, root, entry);
+                ptr = rr_read(ptr, &n, root, entry, 1);
                 if (!ptr) {
                         errno = ENOSPC;
                         goto err;

--- a/mdns.c
+++ b/mdns.c
@@ -203,24 +203,7 @@ mdns_free(struct rr_entry *entries)
 
         while ((entry = entries)) {
                 entries = entries->next;
-                switch (entry->type) {
-                        case RR_SRV:
-                                free(entry->data.SRV.target);
-                                break;
-                        case RR_PTR:
-                                free(entry->data.PTR.domain);
-                                break;
-                        case RR_TXT: {
-                                struct rr_data_txt *text, *TXT;
-
-                                TXT = entry->data.TXT;
-                                while ((text = TXT)) {
-                                        TXT = TXT->next;
-                                        free(text);
-                                }
-                        }
-                }
-                free(entry->name);
+                rr_free(entry);
                 free(entry);
         }
 }

--- a/microdns.h.in
+++ b/microdns.h.in
@@ -79,6 +79,9 @@ extern void mdns_print(const struct rr_entry *);
 extern int mdns_strerror(int, char *, size_t);
 extern int mdns_listen(const struct mdns_ctx *ctx, const char *name, enum rr_type type, unsigned int interval,
         mdns_stop_func stop, mdns_callback callback, void *p_cookie);
+extern int mdns_announce(struct mdns_ctx *ctx, const char *service, enum rr_type,
+        mdns_callback callback, void *p_cookie);
+extern int mdns_serve(struct mdns_ctx *ctx, mdns_stop_func stop, void *p_cookie);
 
 # ifdef __cplusplus
 }

--- a/microdns.h.in
+++ b/microdns.h.in
@@ -37,7 +37,34 @@ struct mdns_ctx;
 #define MDNS_ADDR_IPV4   "224.0.0.251"
 #define MDNS_ADDR_IPV6   "FF02::FB"
 
+#define GET_RCODE(x)    (x&0x000f)
+#define SET_RCODE(x,c)  (x|(c&0x000f))
+ 
+#define GET_OPCODE(x)   (x&0x7800)
+#define SET_OPCODE(x,c) (x|(c&0x7800))
+ 
+ enum mdns_hdr_flag {
+       FLAG_QR = 1 << 15, // Question/Response
+       FLAG_AA = 1 << 10, // Authoritative Answer
+       FLAG_TC = 1 <<  9, // Truncated Response
+       FLAG_RD = 1 <<  8, // Recursion Desired
+       FLAG_RA = 1 <<  7, // Recursion Available
+       FLAG_Z  = 1 <<  6, // Reserved
+       FLAG_AD = 1 <<  5, // Authentic Data
+       FLAG_CD = 1 <<  4, // Checking Disabled
+};
+
+struct mdns_hdr {
+        uint16_t id;
+        uint16_t flags;
+        uint16_t num_qn;
+        uint16_t num_ans_rr;
+        uint16_t num_auth_rr;
+        uint16_t num_add_rr;
+};
+
 typedef void (*mdns_callback)(void*, int, const struct rr_entry *);
+
 /**
  * \return true if the listener should be stopped
  */
@@ -45,13 +72,13 @@ typedef bool (*mdns_stop_func)(void*);
 
 extern int mdns_init(struct mdns_ctx **ctx, const char *addr, unsigned short port);
 extern int mdns_cleanup(struct mdns_ctx *ctx);
-extern int mdns_send(const struct mdns_ctx *ctx, enum rr_type, const char *);
+extern int mdns_send(const struct mdns_ctx *ctx, const struct mdns_hdr *hdr, const struct rr_entry *entries);
 extern void mdns_free(struct rr_entry *);
-extern int mdns_recv(const struct mdns_ctx *ctx, struct rr_entry **);
+extern int mdns_recv(const struct mdns_ctx *ctx, struct mdns_hdr *hdr, struct rr_entry **);
 extern void mdns_print(const struct rr_entry *);
 extern int mdns_strerror(int, char *, size_t);
-extern int mdns_listen(const struct mdns_ctx *ctx, const char *name, unsigned int interval,
-    mdns_stop_func stop, mdns_callback callback, void* p_callback_cookie);
+extern int mdns_listen(const struct mdns_ctx *ctx, const char *name, enum rr_type type, unsigned int interval,
+        mdns_stop_func stop, mdns_callback callback, void *p_cookie);
 
 # ifdef __cplusplus
 }

--- a/rr.c
+++ b/rr.c
@@ -318,16 +318,18 @@ err:
 uint8_t *
 rr_encode(char *s)
 {
-        uint8_t *buf, *b;
-        char *l, *p;
+        uint8_t *buf, *b, l = 0;
+        char *p = s;
 
         buf = malloc(strlen(s) + 2);
         if (!buf)
                 return (NULL);
-        for (b = buf, p = strtok_r(s, ".", &l); p; p = strtok_r(NULL, ".", &l)) {
-                *b = strlen(p);
-                memcpy(b + 1, p, *b);
-                b += *b + 1;
+        for (b = buf, l = strcspn(p, "."); l > 0;
+                l = *p ? strcspn(++p, ".") : 0) {
+                *b = l;
+                memcpy(b + 1, p, l);
+                b += l + 1;
+                p += l;
         }
         *b = 0;
         return (buf);

--- a/rr.c
+++ b/rr.c
@@ -463,3 +463,32 @@ rr_print(const struct rr_entry *entry)
 
         printf("}");
 }
+
+void
+rr_free(struct rr_entry *entry)
+{
+        if (!entry) return;
+
+        switch (entry->type) {
+        case RR_SRV:
+                if (entry->data.SRV.target)
+                         free(entry->data.SRV.target);
+        break;
+        case RR_PTR:
+                if (entry->data.PTR.domain)
+                        free(entry->data.PTR.domain);
+        break;
+        case RR_TXT:
+        {
+                struct rr_data_txt *text, *TXT;
+
+                TXT = entry->data.TXT;
+                while ((text = TXT)) {
+                        TXT = TXT->next;
+                        if (text)
+                               free(text);
+                }
+        }}
+        if (entry->name)
+                free(entry->name);
+}

--- a/rr.h
+++ b/rr.h
@@ -99,6 +99,7 @@ extern uint8_t *rr_encode(char *);
 extern const uint8_t *rr_read(const uint8_t *, size_t *, const uint8_t *, struct rr_entry *, int8_t ans);
 extern ssize_t rr_write(uint8_t *, const struct rr_entry *, int8_t ans);
 extern void rr_print(const struct rr_entry *);
+extern void rr_free(struct rr_entry *);
 
 # ifdef __cplusplus
 }

--- a/rr.h
+++ b/rr.h
@@ -91,11 +91,13 @@ struct rr_entry {
 };
 
 typedef const uint8_t *(*rr_reader)(const uint8_t *, size_t *, const uint8_t *, struct rr_entry *);
+typedef ssize_t (*rr_writer)(uint8_t *, const struct rr_entry *);
 typedef void (*rr_printer)(const union rr_data *);
 
 extern const uint8_t *rr_decode(const uint8_t *, size_t *, const uint8_t *, char **);
 extern uint8_t *rr_encode(char *);
-extern const uint8_t *rr_read(const uint8_t *, size_t *, const uint8_t *, struct rr_entry *);
+extern const uint8_t *rr_read(const uint8_t *, size_t *, const uint8_t *, struct rr_entry *, int8_t ans);
+extern ssize_t rr_write(uint8_t *, const struct rr_entry *, int8_t ans);
 extern void rr_print(const struct rr_entry *);
 
 # ifdef __cplusplus

--- a/utils.h
+++ b/utils.h
@@ -48,6 +48,15 @@ static inline uint8_t *write_u16(uint8_t *p, const uint16_t v)
         return (p);
 }
 
+static inline uint8_t *write_u32(uint8_t *p, const uint16_t v)
+{
+        *p++ = (v >> 24) & 0xFF;
+        *p++ = (v >> 16) & 0xFF;
+        *p++ = (v >>  8) & 0xFF;
+        *p++ = (v >>  0) & 0xFF;
+        return (p);
+}
+
 static inline uint8_t *write_raw(uint8_t *p, const uint8_t *v)
 {
         size_t len;


### PR DESCRIPTION
thank you for this library, it is really helpful and i really appreciate the small footprint.

i needed the ability to also announce mdns packets as well so ive made the following changes.
i offer the following for merge consideration in case its useful to others with similar use case.

up to 8b74eb7 the api should be backwards compatible.

the last few commits break the previous api but reduce the code size by generalizing common logic.
