### PR TITLE
build: split compat into its own library.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,23 +2,26 @@ ACLOCAL_AMFLAGS = -I m4
 
 AM_CPPFLAGS = -I. -I$(top_srcdir)/src -I$(top_srcdir)/compat -I$(top_builddir)/src
 
+lib_LTLIBRARIES = libmicrodns.la
+noinst_LTLIBRARIES = libcompat.la
+
+libcompat_la_SOURCES = compat/compat.c compat/compat.h
+
 libmicrodns_la_SOURCES = \
-	compat/compat.c compat/compat.h \
 	src/mdns.c \
 	src/microdns.h \
 	src/rr.c src/rr.h \
 	src/utils.h
 
-lib_LTLIBRARIES = libmicrodns.la
 libmicrodns_la_LDFLAGS = -no-undefined -export-symbols-regex '^(mdns|rr)_'
-libmicrodns_la_LIBADD = $(LIBSOCKET)
+libmicrodns_la_LIBADD = libcompat.la $(LIBSOCKET)
 
 EXTRA_PROGRAMS = test announce
 
 test_SOURCES = examples/main.c
 test_LDADD = libmicrodns.la
 announce_SOURCES = examples/announce.c
-announce_LDADD = libmicrodns.la
+announce_LDADD = libcompat.la libmicrodns.la
 
 pkginclude_HEADERS = src/microdns.h src/rr.h
 pkgconfig_DATA = src/microdns.pc


### PR DESCRIPTION
This allows using the compat library code in both libmicrodns and in the test programs.
