### PR TITLE
Store interface address and pass to announce callback

### DIFF
--- a/examples/announce.c
+++ b/examples/announce.c
@@ -37,7 +37,7 @@ static bool stop(void *cbarg)
         return (sigflag ? true : false);
 }
 
-static void callback(void *cbarg, int r, const struct rr_entry *entry)
+static void callback(void *cbarg, int r, const struct mdns_ip *mdns_ip, const struct rr_entry *entry)
 {
         struct mdns_ctx *ctx = (struct mdns_ctx *) cbarg;
         struct mdns_hdr hdr = {0};

--- a/examples/announce.c
+++ b/examples/announce.c
@@ -23,20 +23,21 @@
 
 volatile sig_atomic_t sigflag = 0;
 
-void sighandler(int signum)
+static void sighandler(int signum)
 {
         char s[] = "SIGINT received, exiting ...\n";
 
-        write(fileno(stdout), s, sizeof(s));
+        ssize_t result = write(fileno(stdout), s, sizeof(s));
+        (void)result;
         sigflag = 1;
 }
 
-bool stop(void *cbarg)
+static bool stop(void *cbarg)
 {
         return (sigflag ? true : false);
 }
 
-void callback(void *cbarg, int r, const struct rr_entry *entry)
+static void callback(void *cbarg, int r, const struct rr_entry *entry)
 {
         struct mdns_ctx *ctx = (struct mdns_ctx *) cbarg;
         struct mdns_hdr hdr = {0};

--- a/examples/announce.c
+++ b/examples/announce.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <signal.h>
+#include <string.h>
 
 #include "microdns.h"
 #include "compat.h"
@@ -52,8 +53,7 @@ static void callback(void *cbarg, int r, const struct mdns_ip *mdns_ip, const st
         answer.rr_class = entry->rr_class;
         answer.ttl      = 120;
 
-        sprintf(answer.data.A.addr_str, "192.168.1.1");
-        inet_pton(AF_INET, answer.data.A.addr_str, &answer.data.A.addr);
+        memcpy(&answer.data.A.addr, &mdns_ip->ipv4, sizeof(answer.data.A.addr));
         mdns_entries_send(ctx, &hdr, &answer);
 }
 

--- a/examples/main.c
+++ b/examples/main.c
@@ -28,7 +28,8 @@ static void sighandler(int signum)
 {
         char s[] = "SIGINT received, exiting ...\n";
 
-        write(fileno(stdout), s, sizeof(s));
+        ssize_t result = write(fileno(stdout), s, sizeof(s));
+        (void)result;
         sigflag = 1;
 }
 

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -194,8 +194,12 @@ mdns_list_interfaces(multicast_if** pp_intfs, size_t* p_nb_intf, int ai_family)
                 ++nb_intf;
         }
         if (nb_intf == 0) {
-                *pp_intfs = malloc(sizeof(*intfs));
                 // Fallback to the default interface
+                *pp_intfs = malloc(sizeof(*intfs));
+                if (*pp_intfs == NULL) {
+                        free(res);
+                        return (MDNS_ERROR);
+                }
                 **pp_intfs = 0;
                 *p_nb_intf = 1;
                 return (0);
@@ -216,6 +220,7 @@ mdns_list_interfaces(multicast_if** pp_intfs, size_t* p_nb_intf, int ai_family)
                 ++intfs;
         }
         *p_nb_intf = nb_intf;
+        free(res);
         return (0);
 }
 #endif

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -43,7 +43,11 @@
 struct mdns_svc {
         char *name;
         enum rr_type type;
-        mdns_callback callback;
+        union
+        {
+                mdns_announce_callback announce_callback;
+                //mdns_listen_callback listen_callback;  // currently unused
+        };
         void *p_cookie;
         struct mdns_svc *next;
 };
@@ -521,7 +525,7 @@ strrcmp(const char *s1, const char *s2)
 
 static int
 mdns_listen_probe_network(const struct mdns_ctx *ctx, const char *const names[],
-                          unsigned int nb_names, mdns_callback callback,
+                          unsigned int nb_names, mdns_listen_callback callback,
                           void *p_cookie)
 {
     struct mdns_hdr ahdr = {0};
@@ -570,7 +574,7 @@ mdns_listen_probe_network(const struct mdns_ctx *ctx, const char *const names[],
 int
 mdns_listen(const struct mdns_ctx *ctx, const char *const names[],
             unsigned int nb_names, enum rr_type type, unsigned int interval,
-            mdns_stop_func stop, mdns_callback callback, void *p_cookie)
+            mdns_stop_func stop, mdns_listen_callback callback, void *p_cookie)
 {
         if (ctx->nb_conns == 0)
                 return (MDNS_ERROR);
@@ -617,7 +621,7 @@ mdns_listen(const struct mdns_ctx *ctx, const char *const names[],
 
 int
 mdns_announce(struct mdns_ctx *ctx, const char *service, enum rr_type type,
-        mdns_callback callback, void *p_cookie)
+        mdns_announce_callback callback, void *p_cookie)
 {
         if (!callback)
                 return (MDNS_ERROR);
@@ -628,7 +632,7 @@ mdns_announce(struct mdns_ctx *ctx, const char *service, enum rr_type type,
 
         svc->name = strdup(service);
         svc->type = type;
-        svc->callback = callback;
+        svc->announce_callback = callback;
         svc->p_cookie = p_cookie;
         svc->next  = ctx->services;
 
@@ -670,7 +674,7 @@ mdns_serve(struct mdns_ctx *ctx, mdns_stop_func stop, void *p_cookie)
 
                         for (svc = ctx->services; svc; svc = svc->next) {
                                 if (!strrcmp(question->name, svc->name) && question->type == svc->type) {
-                                        svc->callback(svc->p_cookie, r, question);
+                                        svc->announce_callback(svc->p_cookie, r, NULL, question);
                                         goto again;
                                 }
                         }

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -91,9 +91,10 @@ mdns_is_interface_valuable(struct ifaddrs* ifa)
 }
 
 static int
-mdns_list_interfaces(multicast_if** pp_intfs, size_t* p_nb_intf, int ai_family)
+mdns_list_interfaces(multicast_if** pp_intfs, struct mdns_ip **pp_mdns_ips, size_t* p_nb_intf, int ai_family)
 {
         struct ifaddrs *ifs;
+        struct mdns_ip *mdns_ips;
         struct ifaddrs *c;
         size_t nb_if;
         multicast_if* intfs;
@@ -118,12 +119,27 @@ mdns_list_interfaces(multicast_if** pp_intfs, size_t* p_nb_intf, int ai_family)
                 freeifaddrs(ifs);
                 return (MDNS_ERROR);
         }
+        *pp_mdns_ips = mdns_ips = malloc(sizeof(*mdns_ips) * nb_if);
+        if (mdns_ips == NULL) {
+                free(intfs);
+                freeifaddrs(ifs);
+                return (MDNS_ERROR);
+        }
         for (c = ifs; c != NULL; c = c->ifa_next) {
                 if (c->ifa_addr == NULL ||
                     c->ifa_addr->sa_family != ai_family ||
                     !mdns_is_interface_valuable(c))
                         continue;
                 memcpy(intfs, c->ifa_addr, sizeof(*intfs));
+                if (ai_family == AF_INET) {
+                        struct sockaddr_in *addr_in = (struct sockaddr_in *)c->ifa_addr;
+                        memcpy(&(*mdns_ips).ipv4.addr, &addr_in->sin_addr, sizeof(struct in_addr));
+                }
+                else {
+                        struct sockaddr_in6 *addr_in = (struct sockaddr_in6 *)c->ifa_addr;
+                        memcpy(&(*mdns_ips).ipv6.addr, &addr_in->sin6_addr, sizeof(struct in6_addr));
+                }
+                mdns_ips++;
                 intfs++;
         }
         freeifaddrs(ifs);
@@ -132,13 +148,20 @@ mdns_list_interfaces(multicast_if** pp_intfs, size_t* p_nb_intf, int ai_family)
 }
 #else
 static size_t
-mdns_list_interfaces(multicast_if** pp_intfs, size_t* p_nb_intf, int ai_family)
+mdns_list_interfaces(multicast_if** pp_intfs, struct mdns_ip **pp_mdns_ips, size_t* p_nb_intf, int ai_family)
 {
         multicast_if *intfs;
+        struct mdns_ip *mdns_ips;
         *pp_intfs = intfs = malloc(sizeof(*intfs));
         if (intfs == NULL)
                 return (MDNS_ERROR);
         memset(intfs, 0, sizeof(*intfs));
+        *pp_mdns_ips = mdns_ips = malloc(sizeof(*mdns_ips));
+        if (mdns_ips == NULL) {
+                free(mdns_ips);
+                return (MDNS_ERROR);
+        }
+        memset(mdns_ips, 0, sizeof(*mdns_ips));
         *p_nb_intf = 1;
         return (0);
 }
@@ -154,9 +177,10 @@ mdns_is_interface_valuable(IP_ADAPTER_ADDRESSES *intf)
 }
 
 static size_t
-mdns_list_interfaces(multicast_if** pp_intfs, size_t* p_nb_intf, int ai_family)
+mdns_list_interfaces(multicast_if** pp_intfs, struct mdns_ip **pp_mdns_ips, size_t* p_nb_intf, int ai_family)
 {
         multicast_if* intfs;
+        struct mdns_ip *mdns_ips;
         IP_ADAPTER_ADDRESSES *res = NULL, *current;
         ULONG size;
         HRESULT hr;
@@ -179,8 +203,8 @@ mdns_list_interfaces(multicast_if** pp_intfs, size_t* p_nb_intf, int ai_family)
                 res = malloc( size );
                 if (res == NULL)
                         return (MDNS_ERROR);
-                hr = GetAdaptersAddresses(ai_family, GAA_FLAG_SKIP_UNICAST |
-                                                    GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_DNS_SERVER,
+                hr = GetAdaptersAddresses(ai_family, GAA_FLAG_SKIP_ANYCAST |
+                                                    GAA_FLAG_SKIP_DNS_SERVER,
                                                     NULL, res, &size);
         } while (hr == ERROR_BUFFER_OVERFLOW);
         if (hr != NO_ERROR) {
@@ -201,12 +225,25 @@ mdns_list_interfaces(multicast_if** pp_intfs, size_t* p_nb_intf, int ai_family)
                         return (MDNS_ERROR);
                 }
                 **pp_intfs = 0;
+                *pp_mdns_ips = malloc(sizeof(*mdns_ips));
+                if (*pp_mdns_ips == NULL) {
+                        free(*pp_intfs);
+                        free(res);
+                        return (MDNS_ERROR);
+                }
+                memset(mdns_ips, 0, sizeof(*mdns_ips));
                 *p_nb_intf = 1;
                 return (0);
         }
 
         *pp_intfs = intfs = malloc(nb_intf * sizeof(*intfs));
         if (intfs == NULL) {
+                free(res);
+                return (MDNS_ERROR);
+        }
+        *pp_mdns_ips = mdns_ips = malloc(sizeof(*mdns_ips) * nb_intf);
+        if (mdns_ips == NULL) {
+                free(intfs);
                 free(res);
                 return (MDNS_ERROR);
         }
@@ -217,6 +254,20 @@ mdns_list_interfaces(multicast_if** pp_intfs, size_t* p_nb_intf, int ai_family)
                         *intfs = htonl(current->Ipv6IfIndex);
                 else
                         *intfs = htonl(current->IfIndex);
+                PIP_ADAPTER_UNICAST_ADDRESS_XP p_unicast = current->FirstUnicastAddress;
+                if( p_unicast )
+                {
+                        // Take the first unicast address (highest priority)
+                        if (ai_family == AF_INET) {
+                                struct sockaddr_in *addr_in = (struct sockaddr_in*) p_unicast->Address.lpSockaddr;
+                                memcpy(&(*mdns_ips).ipv4.addr, &addr_in->sin_addr, sizeof(struct in_addr));
+                        }
+                        else {
+                                struct sockaddr_in6 *addr_in = (struct sockaddr_in6*) p_unicast->Address.lpSockaddr;
+                                memcpy(&(*mdns_ips).ipv6.addr, &addr_in->sin6_addr, sizeof(struct in6_addr));
+                        }
+                }
+                ++mdns_ips;
                 ++intfs;
         }
         *p_nb_intf = nb_intf;
@@ -231,6 +282,7 @@ mdns_resolve(struct mdns_ctx *ctx, const char *addr, unsigned short port)
         char buf[6];
         struct addrinfo hints, *res = NULL;
         multicast_if* ifaddrs = NULL;
+        struct mdns_ip *mdns_ips = NULL;
         size_t i;
         int status;
 
@@ -243,7 +295,7 @@ mdns_resolve(struct mdns_ctx *ctx, const char *addr, unsigned short port)
         if (errno != 0)
                 return (MDNS_LKPERR);
 
-        status = mdns_list_interfaces(&ifaddrs, &ctx->nb_conns, res->ai_family);
+        status = mdns_list_interfaces(&ifaddrs, &mdns_ips, &ctx->nb_conns, res->ai_family);
         if ( status < 0) {
                 freeaddrinfo(res);
                 return (status);
@@ -262,9 +314,11 @@ mdns_resolve(struct mdns_ctx *ctx, const char *addr, unsigned short port)
         for (i = 0; i < ctx->nb_conns; ++i ) {
                 ctx->conns[i].sock = INVALID_SOCKET;
                 ctx->conns[i].if_addr = ifaddrs[i];
+                ctx->conns[i].mdns_ip = mdns_ips[i];
                 ctx->conns[i].mdns_ip.family = res->ai_family;
         }
         free(ifaddrs);
+        free(mdns_ips);
         freeaddrinfo(res);
         return (0);
 }
@@ -677,7 +731,7 @@ mdns_serve(struct mdns_ctx *ctx, mdns_stop_func stop, void *p_cookie)
 
                         for (svc = ctx->services; svc; svc = svc->next) {
                                 if (!strrcmp(question->name, svc->name) && question->type == svc->type) {
-                                        svc->announce_callback(svc->p_cookie, r, NULL, question);
+                                        svc->announce_callback(svc->p_cookie, r, &ctx->conns[i].mdns_ip, question);
                                         goto again;
                                 }
                         }

--- a/src/microdns.h
+++ b/src/microdns.h
@@ -72,7 +72,20 @@ struct mdns_hdr {
         uint16_t num_add_rr;
 };
 
-typedef void (*mdns_callback)(void*, int, const struct rr_entry *);
+struct mdns_ip {
+    unsigned int family;
+    union {
+        struct {
+            struct in_addr addr;
+        } ipv4;
+        struct {
+            struct in6_addr addr;
+        } ipv6;
+    };
+};
+
+typedef void (*mdns_listen_callback)(void*, int, const struct rr_entry *);
+typedef void (*mdns_announce_callback)(void*, int, const struct mdns_ip *, const struct rr_entry *);
 
 /**
  * \return true if the listener should be stopped
@@ -148,7 +161,7 @@ extern int mdns_strerror(int error, char *buf, size_t n);
 extern int mdns_listen(const struct mdns_ctx *ctx, const char *const names[],
                        unsigned int nb_names, enum rr_type type,
                        unsigned int interval, mdns_stop_func stop,
-                       mdns_callback callback, void *p_cookie);
+                       mdns_listen_callback callback, void *p_cookie);
 
 /**
  * @brief Announce a new name to serve
@@ -162,7 +175,7 @@ extern int mdns_listen(const struct mdns_ctx *ctx, const char *const names[],
  * @return 0 if success, negative in other cases
  */
 extern int mdns_announce(struct mdns_ctx *ctx, const char *service, enum rr_type type,
-        mdns_callback callback, void *p_cookie);
+        mdns_announce_callback callback, void *p_cookie);
 
 /**
  * @brief The main serving function for mDNS


### PR DESCRIPTION
This allows the announce callback to create A/AAAA records with the address of the interface that received the request.

This means that we can correctly advertise the IP of our service on the local network.