### PR TITLE
Fix build on Windows

### DIFF
--- a/include/mdns.h
+++ b/include/mdns.h
@@ -29,14 +29,15 @@
 
 #include "microdns/microdns.h"
 
-int
+MDNS_EXPORT int
 mdns_parse(struct mdns_hdr *hdr, struct rr_entry **entries, const uint8_t *buf,
            size_t length);
-int
+
+MDNS_EXPORT int
 mdns_write(const struct mdns_hdr *hdr, const struct rr_entry *entries,
            uint8_t *buf, size_t bufSize, size_t* length);
 
-void
+MDNS_EXPORT void
 mdns_free(struct rr_entry *entries);
 
 #endif // MDNS_H


### PR DESCRIPTION
Need to export the new symbols:
```
tests_unittests.c.obj : error LNK2019: unresolved external symbol mdns_parse referenced in function simple_answer_test
tests_unittests.c.obj : error LNK2019: unresolved external symbol mdns_free referenced in function simple_answer_test
subprojects/libmicrodns/unittest.exe : fatal error LNK1120: 2 unresolved externals
```

Also remove old .def and .version files that are no longer used.

Would be great if we could get a new tag/release with this fix.