### PR TITLE
Provide soname

### DIFF
--- a/compat/meson.build
+++ b/compat/meson.build
@@ -1,0 +1,12 @@
+libcompat_sources = [
+    'compat.c',
+    'inet.c',
+    'poll.c',
+]
+
+libcompat = static_library('compat', libcompat_sources,
+    include_directories: incdirs,
+    dependencies: deps,
+    c_args: c_args,
+    link_args: link_flags
+)

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,6 @@
+libmicrodns_headers = [
+    'microdns/microdns.h',
+    'microdns/rr.h',
+]
+
+install_headers(libmicrodns_headers, subdir: 'microdns')

--- a/meson.build
+++ b/meson.build
@@ -172,27 +172,8 @@ endif
 incdirs = include_directories('.', 'include', 'compat')
 
 subdir('compat')
-
-libmicrodns_sources = [
-    'src/mdns.c',
-    'src/rr.c'
-]
-
-libmicrodns_headers = [
-    'include/microdns/microdns.h',
-    'include/microdns/rr.h',
-]
-
-install_headers(libmicrodns_headers, subdir: 'microdns')
-
-libmicrodns = library('microdns', libmicrodns_sources,
-    include_directories: incdirs,
-    link_with: libcompat,
-    link_args: link_flags,
-    dependencies: deps,
-    c_args: c_args,
-    install: true,
-)
+subdir('include')
+subdir('src')
 
 pkg_cdata = configuration_data()
 

--- a/meson.build
+++ b/meson.build
@@ -155,12 +155,6 @@ if cc.get_id() == 'msvc'
 ]
 endif
 
-libcompat_sources = [
-    'compat/compat.c',
-    'compat/inet.c',
-    'compat/poll.c',
-]
-
 link_flags=[]
 
 if get_option('fuzzing')
@@ -177,12 +171,7 @@ endif
 
 incdirs = include_directories('.', 'include', 'compat')
 
-libcompat = static_library('compat', libcompat_sources,
-    include_directories: incdirs,
-    dependencies: deps,
-    c_args: c_args,
-    link_args: link_flags
-)
+subdir('compat')
 
 libmicrodns_sources = [
     'src/mdns.c',

--- a/meson.build
+++ b/meson.build
@@ -30,9 +30,9 @@ project('microdns', ['c'],
                      'b_ndebug=if-release'])
 
 mdns_version = meson.project_version()
+mdns_soname_version = '0.1.0'
 
-ver_arr = mdns_version.split('.')
-
+ver_arr = mdns_soname_version.split('.')
 mdns_major_version = ver_arr[0]
 mdns_minor_version = ver_arr[1]
 mdns_micro_version = ver_arr[2]

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,13 @@
+libmicrodns_sources = [
+    'mdns.c',
+    'rr.c'
+]
+
+libmicrodns = library('microdns', libmicrodns_sources,
+    include_directories: incdirs,
+    link_with: libcompat,
+    link_args: link_flags,
+    dependencies: deps,
+    c_args: c_args,
+    install: true,
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,6 +3,12 @@ libmicrodns_sources = [
     'rr.c'
 ]
 
+if host_machine.system() == 'windows'
+    mdns_soversion = ''
+else
+    mdns_soversion = mdns_major_version
+endif
+
 libmicrodns = library('microdns', libmicrodns_sources,
     include_directories: incdirs,
     link_with: libcompat,
@@ -10,4 +16,6 @@ libmicrodns = library('microdns', libmicrodns_sources,
     dependencies: deps,
     c_args: c_args,
     install: true,
+    soversion: mdns_soversion,
+    version: mdns_soname_version,
 )


### PR DESCRIPTION
This MR cleans up the meson files a bit, and provides a missing soname

The installed layout after this is:
```
/tmp/libmicrodns
├── include
│   └── microdns
│       ├── microdns.h
│       └── rr.h
└── lib
    └── x86_64-linux-gnu
        ├── libmicrodns.a
        ├── libmicrodns.so -> libmicrodns.so.0
        ├── libmicrodns.so.0 -> libmicrodns.so.0.1.0
        ├── libmicrodns.so.0.1.0
        └── pkgconfig
            └── microdns.pc
```

Fix #33 