### PR TITLE
Fix multicast group joining for ipv4

### DIFF
--- a/compat/compat.c
+++ b/compat/compat.c
@@ -105,9 +105,11 @@ os_strerror(int errnum, char *buf, size_t buflen)
 }
 
 int
-os_mcast_join(sock_t s, const struct sockaddr_storage *ss, uint32_t intf_idx)
+os_mcast_join(sock_t s, const struct sockaddr_storage *ss, uint32_t intf_idx,
+              const struct sockaddr_storage* intf_addr)
 {
 #ifdef MCAST_JOIN_GROUP
+        (void)intf_addr;
         struct group_req mgroup;
 
         memset(&mgroup, 0, sizeof(mgroup));
@@ -127,9 +129,10 @@ os_mcast_join(sock_t s, const struct sockaddr_storage *ss, uint32_t intf_idx)
         switch (ss_family(ss)) {
                 case AF_INET: {
                         struct ip_mreq mreq;
+                        const struct sockaddr_in* sin = (const struct sockaddr_in*)intf_addr;
 
                         memcpy(&mreq.imr_multiaddr.s_addr, &u.sin.sin_addr, sizeof(struct in_addr));
-                        memcpy(&mreq.imr_interface, &intf_idx, sizeof(intf_idx));
+                        memcpy(&mreq.imr_interface, &sin->sin_addr, sizeof(sin->sin_addr));
                         if (setsockopt(s, ss_level(ss), IP_ADD_MEMBERSHIP,
                             (const void *) &mreq, sizeof(mreq)) < 0)
                                 return (-1);

--- a/compat/compat.c
+++ b/compat/compat.c
@@ -105,13 +105,13 @@ os_strerror(int errnum, char *buf, size_t buflen)
 }
 
 int
-os_mcast_join(sock_t s, const struct sockaddr_storage *ss, multicast_if mintf)
+os_mcast_join(sock_t s, const struct sockaddr_storage *ss, multicast_if intf_idx)
 {
 #ifdef MCAST_JOIN_GROUP
         struct group_req mgroup;
 
         memset(&mgroup, 0, sizeof(mgroup));
-        mgroup.gr_interface = mintf;
+        mgroup.gr_interface = intf_idx;
         memcpy(&mgroup.gr_group, ss, ss_len(ss));
         if (setsockopt(s, ss_level(ss), MCAST_JOIN_GROUP,
             (const void *) &mgroup, sizeof(mgroup)) < 0)
@@ -129,7 +129,7 @@ os_mcast_join(sock_t s, const struct sockaddr_storage *ss, multicast_if mintf)
                         struct ip_mreq mreq;
 
                         memcpy(&mreq.imr_multiaddr.s_addr, &u.sin.sin_addr, sizeof(struct in_addr));
-                        memcpy(&mreq.imr_interface, &mintf, sizeof(mintf));
+                        memcpy(&mreq.imr_interface, &intf_idx, sizeof(intf_idx));
                         if (setsockopt(s, ss_level(ss), IP_ADD_MEMBERSHIP,
                             (const void *) &mreq, sizeof(mreq)) < 0)
                                 return (-1);
@@ -139,7 +139,7 @@ os_mcast_join(sock_t s, const struct sockaddr_storage *ss, multicast_if mintf)
                         struct ipv6_mreq mreq6;
 
                         memcpy(&mreq6.ipv6mr_multiaddr, &u.sin6.sin6_addr, sizeof(struct in6_addr));
-                        memcpy(&mreq6.ipv6mr_interface, &mintf, sizeof(mintf));
+                        memcpy(&mreq6.ipv6mr_interface, &intf_idx, sizeof(intf_idx));
                         if (setsockopt(s, ss_level(ss), IPV6_JOIN_GROUP,
                             (const void *) &mreq6, sizeof(mreq6)) < 0)
                                 return (-1);

--- a/compat/compat.c
+++ b/compat/compat.c
@@ -105,7 +105,7 @@ os_strerror(int errnum, char *buf, size_t buflen)
 }
 
 int
-os_mcast_join(sock_t s, const struct sockaddr_storage *ss, multicast_if intf_idx)
+os_mcast_join(sock_t s, const struct sockaddr_storage *ss, uint32_t intf_idx)
 {
 #ifdef MCAST_JOIN_GROUP
         struct group_req mgroup;

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -148,6 +148,6 @@ typedef SSIZE_T ssize_t;
 #endif
 
 extern int os_strerror(int, char *, size_t);
-extern int os_mcast_join(sock_t, const struct sockaddr_storage *, multicast_if mintf);
+extern int os_mcast_join(sock_t, const struct sockaddr_storage *, multicast_if intf_idx);
 
 #endif /* MICRODNS_COMPAT_H */

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -143,6 +143,7 @@ typedef SSIZE_T ssize_t;
 #endif
 
 extern int os_strerror(int, char *, size_t);
-extern int os_mcast_join(sock_t, const struct sockaddr_storage *, uint32_t intf_idx);
+extern int os_mcast_join(sock_t, const struct sockaddr_storage *, uint32_t intf_idx,
+                         const struct sockaddr_storage* intf_addr);
 
 #endif /* MICRODNS_COMPAT_H */

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -99,15 +99,10 @@ extern const char *inet_ntop(int af, const void *src, char *dst, socklen_t size)
 extern int inet_pton(int af, const char *src, void *dst);
 # endif // !inet_ntop
 
-typedef DWORD multicast_if;
-
 #else
 
 # if HAVE_IFADDRS_H
 #include <ifaddrs.h>
-typedef uint32_t multicast_if;
-# else
-typedef void* multicast_if;
 # endif
 
 #endif // _WIN32
@@ -148,6 +143,6 @@ typedef SSIZE_T ssize_t;
 #endif
 
 extern int os_strerror(int, char *, size_t);
-extern int os_mcast_join(sock_t, const struct sockaddr_storage *, multicast_if intf_idx);
+extern int os_mcast_join(sock_t, const struct sockaddr_storage *, uint32_t intf_idx);
 
 #endif /* MICRODNS_COMPAT_H */

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -486,7 +486,7 @@ mdns_init(struct mdns_ctx **p_ctx, const char *addr, unsigned short port)
 
             if (setsockopt(ctx->conns[i].sock, ss_level(&ctx->conns[i].intf_addr),
                            ctx->conns[i].intf_addr.ss_family == AF_INET ? IP_MULTICAST_LOOP : IPV6_MULTICAST_LOOP,
-                           (const bool *) &loop, sizeof(loop)) < 0) {
+                           (const void *) &loop, sizeof(loop)) < 0) {
                     return mdns_destroy(ctx), (MDNS_NETERR);
             }
         }

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -54,7 +54,7 @@ struct mdns_svc {
 
 struct mdns_conn {
         sock_t sock;
-        multicast_if intf_idx;
+        uint32_t intf_idx;
         struct sockaddr_storage intf_addr;  // IP address and family of the interface
         struct sockaddr_storage mcast_addr; // The multicast address targeted by this connection
 };
@@ -114,7 +114,7 @@ static size_t count_interfaces(const struct ifaddrs *ifs,
 }
 
 static int
-mdns_list_interfaces(multicast_if** pp_intfs, struct sockaddr_storage **pp_mdns_ips,
+mdns_list_interfaces(uint32_t** pp_intfs, struct sockaddr_storage **pp_mdns_ips,
                      size_t* p_nb_intf, struct sockaddr_storage **pp_mcast_addrs,
                      const struct addrinfo* addrs)
 {
@@ -123,7 +123,7 @@ mdns_list_interfaces(multicast_if** pp_intfs, struct sockaddr_storage **pp_mdns_
         struct ifaddrs *c;
         struct sockaddr_storage *mcast_addrs;
         size_t nb_if;
-        multicast_if* intfs;
+        uint32_t* intfs;
 
         *p_nb_intf = 0;
         if (getifaddrs(&ifs) || ifs == NULL)
@@ -179,9 +179,9 @@ mdns_list_interfaces(multicast_if** pp_intfs, struct sockaddr_storage **pp_mdns_
 }
 #else
 static size_t
-mdns_list_interfaces(multicast_if** pp_intfs, struct sockaddr_storage **pp_mdns_ips, size_t* p_nb_intf, int ai_family)
+mdns_list_interfaces(uint32_t** pp_intfs, struct sockaddr_storage **pp_mdns_ips, size_t* p_nb_intf, int ai_family)
 {
-        multicast_if *intfs;
+        uint32_t *intfs;
         struct sockaddr_storage *mdns_ips;
         *pp_intfs = intfs = malloc(sizeof(*intfs));
         if (intfs == NULL)
@@ -211,11 +211,11 @@ mdns_is_interface_valuable(IP_ADAPTER_ADDRESSES *intf, int family)
 }
 
 static size_t
-mdns_list_interfaces(multicast_if** pp_intfs, struct sockaddr_storage **pp_mdns_ips,
+mdns_list_interfaces(uint32_t** pp_intfs, struct sockaddr_storage **pp_mdns_ips,
                      size_t* p_nb_intf, struct sockaddr_storage **pp_mcast_addrs,
                      const struct addrinfo* addrs)
 {
-        multicast_if* intfs;
+        uint32_t* intfs;
         struct sockaddr_storage *mdns_ips;
         struct sockaddr_storage *mcast_addrs;
         IP_ADAPTER_ADDRESSES *res = NULL, *current;
@@ -350,7 +350,7 @@ mdns_resolve(struct mdns_ctx *ctx, const char *addr, unsigned short port)
 {
         char buf[6];
         struct addrinfo hints, *res = NULL;
-        multicast_if* ifaddrs = NULL;
+        uint32_t* ifaddrs = NULL;
         struct sockaddr_storage *mdns_ips = NULL;
         struct sockaddr_storage *mcast_addrs = NULL;
         size_t i;

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -54,7 +54,7 @@ struct mdns_svc {
 
 struct mdns_conn {
         sock_t sock;
-        multicast_if if_addr;  // NB: In Windows this is the interface index
+        multicast_if intf_idx;
         struct sockaddr_storage intf_addr;  // IP address and family of the interface
         struct sockaddr_storage mcast_addr; // The multicast address targeted by this connection
 };
@@ -412,7 +412,7 @@ mdns_resolve(struct mdns_ctx *ctx, const char *addr, unsigned short port)
         }
         for (i = 0; i < ctx->nb_conns; ++i ) {
                 ctx->conns[i].sock = INVALID_SOCKET;
-                ctx->conns[i].if_addr = ifaddrs[i];
+                ctx->conns[i].intf_idx = ifaddrs[i];
                 ctx->conns[i].intf_addr = mdns_ips[i];
                 ctx->conns[i].mcast_addr = mcast_addrs[i];
         }
@@ -475,7 +475,7 @@ mdns_init(struct mdns_ctx **p_ctx, const char *addr, unsigned short port)
                      ss_len(&dumb.ss)) < 0)
                     return mdns_destroy(ctx), (MDNS_NETERR);
 
-            if (os_mcast_join(ctx->conns[i].sock, ss_addr, ctx->conns[i].if_addr) < 0)
+            if (os_mcast_join(ctx->conns[i].sock, ss_addr, ctx->conns[i].intf_idx) < 0)
                     return mdns_destroy(ctx), (MDNS_NETERR);
             if (setsockopt(ctx->conns[i].sock, ss_level(&ctx->conns[i].intf_addr),
                            ctx->conns[i].intf_addr.ss_family == AF_INET ? IP_MULTICAST_TTL : IPV6_MULTICAST_HOPS,

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -475,7 +475,8 @@ mdns_init(struct mdns_ctx **p_ctx, const char *addr, unsigned short port)
                      ss_len(&dumb.ss)) < 0)
                     return mdns_destroy(ctx), (MDNS_NETERR);
 
-            if (os_mcast_join(ctx->conns[i].sock, ss_addr, ctx->conns[i].intf_idx) < 0)
+            if (os_mcast_join(ctx->conns[i].sock, ss_addr, ctx->conns[i].intf_idx,
+                              &ctx->conns[i].intf_addr) < 0)
                     return mdns_destroy(ctx), (MDNS_NETERR);
             if (setsockopt(ctx->conns[i].sock, ss_level(&ctx->conns[i].intf_addr),
                            ctx->conns[i].intf_addr.ss_family == AF_INET ? IP_MULTICAST_TTL : IPV6_MULTICAST_HOPS,


### PR DESCRIPTION
When using `IP_ADD_MEMBERSHIP` we need to use the interface's address, not its index