### PR TITLE
Add hostname lookup support

### DIFF
--- a/examples/host-lookup.c
+++ b/examples/host-lookup.c
@@ -67,10 +67,13 @@ static void callback(void *p_cookie, int status, const struct rr_entry *entries)
         }
         entry = (struct rr_entry *) entries;
         while (entry) {
-                if (entry->type == RR_A)
-                        printf("%s resolves to IPv4 address %s\n", hostname, entry->data.A.addr_str);
-                if (entry->type == RR_AAAA)
-                        printf("%s resolves to IPv6 address %s\n", hostname, entry->data.AAAA.addr_str);
+                if (entry->valid)
+                {
+                        if (entry->type == RR_A)
+                                printf("%s resolves to IPv4 address %s\n", hostname, entry->data.A.addr_str);
+                        else if (entry->type == RR_AAAA)
+                                printf("%s resolves to IPv6 address %s\n", hostname, entry->data.AAAA.addr_str);
+                }
                 entry = entry->next;
         }
         stopflag = true;

--- a/examples/host-lookup.c
+++ b/examples/host-lookup.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2014-2015 VideoLabs SAS
+ * Copyright © 2021 Red Hat Inc
+ *
+ * Authors: Jonathan Calmels <jbjcalmels@gmail.com>
+ *          Bastien Nocera <hadess@hadess.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <compat.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <time.h>
+
+#include <microdns/microdns.h>
+
+#include "compat.h"
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#define TIMEOUT 1
+
+static bool stopflag = false;
+static time_t start_time;
+
+static double get_elapsed(void)
+{
+        time_t t;
+
+        t = time(NULL);
+        return difftime(t, start_time);
+}
+
+static bool stop(void *p_cookie)
+{
+        double elapsed;
+        if (stopflag)
+                return stopflag;
+        elapsed = get_elapsed();
+        return elapsed >= (double) TIMEOUT;
+}
+
+static void callback(void *p_cookie, int status, const struct rr_entry *entries)
+{
+        struct rr_entry *entry;
+        char *hostname = p_cookie;
+        char err[128];
+
+        if (status < 0) {
+                mdns_strerror(status, err, sizeof(err));
+                fprintf(stderr, "error: %s\n", err);
+                return;
+        }
+        entry = (struct rr_entry *) entries;
+        while (entry) {
+                if (entry->type == RR_A)
+                        printf("%s resolves to IPv4 address %s\n", hostname, entry->data.A.addr_str);
+                if (entry->type == RR_AAAA)
+                        printf("%s resolves to IPv6 address %s\n", hostname, entry->data.AAAA.addr_str);
+                entry = entry->next;
+        }
+        stopflag = true;
+}
+
+int main(int i_argc, char *ppsz_argv[])
+{
+        int r = 0;
+        char err[128];
+        struct mdns_ctx *ctx;
+        const char **ppsz_names;
+        int i_nb_names;
+
+        if (i_argc <= 1)
+        {
+                fprintf(stderr, "Usage: %s [HOSTNAME]\n", ppsz_argv[0]);
+                return (1);
+        }
+
+        ppsz_names = (const char **) &ppsz_argv[1];
+        i_nb_names = i_argc - 1;
+
+        if ((r = mdns_init(&ctx, NULL, MDNS_PORT)) < 0)
+                goto err;
+        start_time = time(NULL);
+        if ((r = mdns_listen(ctx, ppsz_names, i_nb_names, RR_A, TIMEOUT, stop,
+                             callback, ppsz_argv[1])) < 0)
+                goto err;
+        stopflag = false;
+        start_time = time(NULL);
+        if ((r = mdns_listen(ctx, ppsz_names, i_nb_names, RR_AAAA, TIMEOUT, stop,
+                             callback, ppsz_argv[1])) < 0)
+                goto err;
+err:
+        if (r < 0) {
+                mdns_strerror(r, err, sizeof(err));
+                fprintf(stderr, "fatal: %s\n", err);
+        }
+        mdns_destroy(ctx);
+        return (0);
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -11,4 +11,5 @@ examples_kwargs = {
 
 executable('listen', 'main.c', kwargs: examples_kwargs)
 executable('announce', 'announce.c', kwargs: examples_kwargs)
+executable('host-lookup', 'host-lookup.c', kwargs: examples_kwargs)
 

--- a/include/microdns/rr.h
+++ b/include/microdns/rr.h
@@ -95,6 +95,7 @@ struct rr_entry {
 
         /* Answers only */
         uint32_t ttl;
+        uint16_t valid : 1; // whether the answer is valid for the request
         uint16_t data_len;
         union    rr_data data;
 

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -752,6 +752,19 @@ is_host_address_rr_type(enum rr_type type)
         return (type == RR_A || type == RR_AAAA);
 }
 
+/* A lookup of 'foo.local.' or 'foo.local' will
+ * match a result of 'foo.local' */
+static bool
+hostname_match(const char *hostname, const char *match)
+{
+        unsigned int len;
+
+        len = strlen(hostname);
+        if (hostname[len-1] == '.')
+                len--;
+        return (!strncasecmp (hostname, match, len));
+}
+
 static int
 mdns_listen_probe_network(const struct mdns_ctx *ctx, const char *const names[],
                           unsigned int nb_names, mdns_listen_callback callback,
@@ -793,7 +806,7 @@ mdns_listen_probe_network(const struct mdns_ctx *ctx, const char *const names[],
                                     callback(p_cookie, r, entries);
                                     break;
                             } else if (is_host_address_rr_type(entry->type) &&
-                                    !strcasecmp (entry->name, names[i])) {
+                                    hostname_match(names[i], entry->name)) {
                                     callback(p_cookie, r, entries);
                                     break;
                             }

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -729,6 +729,12 @@ strrcmp(const char *s, const char *sub)
         return (strncmp(s + m - n, sub, n));
 }
 
+static bool
+is_host_address_rr_type(enum rr_type type)
+{
+        return (type == RR_A || type == RR_AAAA);
+}
+
 static int
 mdns_listen_probe_network(const struct mdns_ctx *ctx, const char *const names[],
                           unsigned int nb_names, mdns_listen_callback callback,
@@ -767,6 +773,10 @@ mdns_listen_probe_network(const struct mdns_ctx *ctx, const char *const names[],
             for (struct rr_entry *entry = entries; entry; entry = entry->next) {
                     for (unsigned int i = 0; i < nb_names; ++i) {
                             if (!strrcmp(entry->name, names[i])) {
+                                    callback(p_cookie, r, entries);
+                                    break;
+                            } else if (is_host_address_rr_type(entry->type) &&
+                                    !strcasecmp (entry->name, names[i])) {
                                     callback(p_cookie, r, entries);
                                     break;
                             }

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -730,6 +730,23 @@ strrcmp(const char *s, const char *sub)
 }
 
 static bool
+hostname_has_two_labels(const char *hostname)
+{
+        unsigned int i, num_dots;
+
+        if (!hostname)
+                return false;
+
+        for (i = 0, num_dots = 0; hostname[i] != '\0' && num_dots < 2; i++)
+        {
+                if (hostname[i] == '.' && hostname[i+1] != '\0')
+                        num_dots++;
+        }
+
+        return (num_dots == 1);
+}
+
+static bool
 is_host_address_rr_type(enum rr_type type)
 {
         return (type == RR_A || type == RR_AAAA);
@@ -808,6 +825,16 @@ mdns_listen(const struct mdns_ctx *ctx, const char *const names[],
                 qns[i].name     = (char *)names[i];
                 qns[i].type     = type;
                 qns[i].rr_class = RR_IN;
+
+                if (is_host_address_rr_type(type))
+                {
+                        if (!hostname_has_two_labels(qns[i].name))
+                        {
+                                free(qns);
+                                return (MDNS_ERROR);
+                        }
+                }
+
                 if (i + 1 < nb_names)
                     qns[i].next = &qns[i+1];
         }

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -828,7 +828,8 @@ mdns_listen(const struct mdns_ctx *ctx, const char *const names[],
 
                 if (is_host_address_rr_type(type))
                 {
-                        if (!hostname_has_two_labels(qns[i].name))
+                        if (!hostname_has_two_labels(qns[i].name) ||
+                            !(!strrcmp(qns[i].name, ".local") || !strrcmp(qns[i].name, ".local.")))
                         {
                                 free(qns);
                                 return (MDNS_ERROR);

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -758,7 +758,7 @@ mdns_listen_probe_network(const struct mdns_ctx *ctx, const char *const names[],
                     continue;
             }
 
-            if (ahdr.num_ans_rr + ahdr.num_add_rr == 0)
+            if (ahdr.num_ans_rr + ahdr.num_auth_rr + ahdr.num_add_rr == 0)
             {
                     mdns_free(entries);
                     continue;


### PR DESCRIPTION
Example output from the test tool (replaced the IPv6 address though):
```sh
$ ~/.cache/jhbuild/build/microdns/examples/host-lookup diskstation.local
diskstation.local resolves to IPv4 address 192.168.1.68
diskstation.local resolves to IPv6 address ffff:fff:ffff:ffff:fff:ffff:fffff:fffff
```

Please check carefully.