### PR TITLE
Meson: Simplify pkgconfig generator

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -186,14 +186,6 @@ subdir('compat')
 subdir('include')
 subdir('src')
 
-pkg_cdata = configuration_data()
-
-pkg_cdata.set('prefix', join_paths(get_option('prefix')))
-pkg_cdata.set('exec_prefix', '${prefix}')
-pkg_cdata.set('libdir', '${prefix}/@0@'.format(get_option('libdir')))
-pkg_cdata.set('includedir', '${prefix}/@0@'.format(get_option('includedir')))
-pkg_cdata.set('VERSION', mdns_version)
-
 mdns_dep = declare_dependency(link_with : libmicrodns,
     include_directories : incdirs,
     dependencies: deps,

--- a/src/meson.build
+++ b/src/meson.build
@@ -21,10 +21,8 @@ libmicrodns = library('microdns', libmicrodns_sources,
 )
 
 pkgconf = import('pkgconfig')
-pkgconf.generate(libraries: libmicrodns,
-                 version: mdns_version,
+pkgconf.generate(libmicrodns,
                  name: 'microDNS',
                  description: 'mDNS simple implementation',
                  filebase: 'microdns',
-                 requires: deps,
 )


### PR DESCRIPTION
- pkg_cdata is unused and should have been deleted completely
- libmicrodns should be passed as first positional argument and not in
  libraries: keyword argument.
- deps should not be specified as public requires, they are private
  dependencies and Meson will add them automatically, no need to mention
  them.