### PR TITLE
Add PIC parameter to fix builds for some platforms

### DIFF
--- a/compat/meson.build
+++ b/compat/meson.build
@@ -8,5 +8,6 @@ libcompat = static_library('compat', libcompat_sources,
     include_directories: incdirs,
     dependencies: deps,
     c_args: c_args,
-    link_args: link_flags
+    link_args: link_flags,
+    pic: true
 )


### PR DESCRIPTION
On some platforms (such as UWP), the static library must have position independent code (PIC) to be included properly in a shared library.