### PR TITLE
mdns: detect goodbye packets per RFC 6762 §11.3

### DIFF
--- a/compat/compat.h
+++ b/compat/compat.h
@@ -28,6 +28,7 @@ enum {
         MDNS_NETERR = -2, // network error
         MDNS_LKPERR = -3, // lookup error
         MDNS_ERROR  = -4, // any runtime error that's not originating from the standard library
+        MDNS_GOODBYE = 1,  // goodbye packet received (RFC 6762 §11.3, TTL=0)
 };
 
 /*

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -767,7 +767,12 @@ mdns_listen_probe_network(const struct mdns_ctx *ctx, const char *const names[],
             for (struct rr_entry *entry = entries; entry; entry = entry->next) {
                     for (unsigned int i = 0; i < nb_names; ++i) {
                             if (!strrcmp(entry->name, names[i])) {
-                                    callback(p_cookie, r, entries);
+                                    /* RFC 6762 §11.3: TTL=0 is a goodbye packet */
+                                    if (entry->ttl == 0) {
+                                            callback(p_cookie, MDNS_GOODBYE, entries);
+                                    } else {
+                                            callback(p_cookie, r, entries);
+                                    }
                                     break;
                             }
                     }


### PR DESCRIPTION
Identify mDNS goodbye packets by checking for TTL=0 in answer records. Previously treated as normal announcements; now trigger listen callback with MDNS_GOODBYE so callers can detect service departure.