### PR TITLE
mdns: fix potential resource leak in mdns_resolve()

### DIFF
--- a/src/mdns.c
+++ b/src/mdns.c
@@ -433,6 +433,9 @@ mdns_resolve(struct mdns_ctx *ctx, const char *addr, unsigned short port)
                 return (status);
         }
         if (ctx->nb_conns == 0) {
+                free(ifaddrs);
+                free(mdns_ips);
+                free(mcast_addrs);
                 freeaddrinfo(res);
                 return (MDNS_NETERR);
         }


### PR DESCRIPTION
## Content

Fix a potential resource leak in `mdns_resolve()`.

When `mdns_list_interfaces()` succeeds but produces `ctx->nb_conns == 0`, the error path returned after freeing only `res` via `freeaddrinfo(res)`. The temporary arrays allocated for interface indexes, local mDNS addresses, and multicast addresses could be left unfreed:

```c
ifaddrs
mdns_ips
mcast_addrs
```

So I add `free` for these variables:

```c
free(ifaddrs);
free(mdns_ips);
free(mcast_addrs);
freeaddrinfo(res);
return (MDNS_NETERR);
```

This does not change normal successful behavior. It only makes the zero-connection error path release all resources consistently.